### PR TITLE
Generate session from request, instead of header

### DIFF
--- a/src/tink/web/routing/Context.hx
+++ b/src/tink/web/routing/Context.hx
@@ -110,14 +110,14 @@ class Context {
       request.header.uri.query
     );
     
-  static public function authed<U, S:Session<U>>(request:IncomingRequest, getSession:IncomingRequestHeader->S) 
+  static public function authed<U, S:Session<U>>(request:IncomingRequest, getSession:IncomingRequest->S) 
     return new AuthedContext<U, S>(
       parseAcceptHeader(request.header),
       request, 
       0,
       request.header.uri.path.parts(), 
       request.header.uri.query,
-      getSession.bind(request.header)
+      getSession.bind(request)
     );
    
   static function parseAcceptHeader(h:Header)


### PR DESCRIPTION
Sometimes we want to get the access token from the query parameter
For some get requests like `<img src="..."/>`, where you can't control the header