### PR TITLE
Use 307 instead of 302

### DIFF
--- a/src/tink/web/routing/Response.hx
+++ b/src/tink/web/routing/Response.hx
@@ -19,7 +19,7 @@ abstract Response(OutgoingResponse) from OutgoingResponse to OutgoingResponse {
   #end
   
   @:from static function ofUrl(u:tink.Url):Response {
-    return new OutgoingResponse(new ResponseHeader(Found, Found, [new HeaderField('location', u)]), Chunk.EMPTY);
+    return new OutgoingResponse(new ResponseHeader(TemporaryRedirect, TemporaryRedirect, [new HeaderField('location', u)]), Chunk.EMPTY);
   }
 
   static public function binary(contentType:String, bytes:Bytes):Response {


### PR DESCRIPTION
307 requires the browser to reuse the same verb as the original request, which I think is more sensible