### PR TITLE
Fixed FormFile abstraction return type

### DIFF
--- a/src/tink/web/forms/FormFile.hx
+++ b/src/tink/web/forms/FormFile.hx
@@ -39,9 +39,9 @@ abstract FormFile(UploadedFile) {
   
   @:from static function ofJson(rep:JsonFileRep):FormFile {
     var data = rep.get();
-    return new FormFile(ofBlob(data.fileName, data.mimeType, data.content));
+    return ofBlob(data.fileName, data.mimeType, data.content);
   }
   
-  static inline public function ofBlob(name:String, type:String, data:Bytes):UploadedFile 
-    return UploadedFile.ofBlob(name, type, data);
+  static inline public function ofBlob(name:String, type:String, data:Bytes):FormFile 
+    return new FormFile(UploadedFile.ofBlob(name, type, data));
 }


### PR DESCRIPTION
This is enable to use the same type on server and client for file uploading.
This solve the problem that demonstrate [here
](https://github.com/mikicho/tink_web_upload_file).