### PR TITLE
Support RealSource #56 (sort of)

### DIFF
--- a/haxe_libraries/tink_json.hxml
+++ b/haxe_libraries/tink_json.hxml
@@ -1,5 +1,4 @@
-# @install: lix --silent download "gh://github.com/haxetink/tink_json#f3ca174cc9edd226c2fcdba0d4a86a3818c2a84b" into tink_json/0.8.0/github/f3ca174cc9edd226c2fcdba0d4a86a3818c2a84b
--D tink_json=0.8.0
--cp ${HAXE_LIBCACHE}/tink_json/0.8.0/github/f3ca174cc9edd226c2fcdba0d4a86a3818c2a84b/src
-
+-D tink_json=0.9.0
+# @install: lix --silent download "gh://github.com/haxetink/tink_json#2b78279cd6a1b01f0e7a7def6f08238596a7cfc0" into tink_json/0.9.0/github/2b78279cd6a1b01f0e7a7def6f08238596a7cfc0
 -lib tink_typecrawler
+-cp ${HAXE_LIBCACHE}/tink_json/0.9.0/github/2b78279cd6a1b01f0e7a7def6f08238596a7cfc0/src

--- a/src/tink/web/macros/Proxify.hx
+++ b/src/tink/web/macros/Proxify.hx
@@ -85,7 +85,7 @@ class Proxify {
   
   static function build(ctx:BuildContext):TypeDefinition {
     var routes = RouteSyntax.read(ctx.type, ['application/json'], ['application/json']);
-    var t = {
+    return {
       pos: ctx.pos,
       pack: ['tink', 'web'],
       name: ctx.name,
@@ -190,10 +190,6 @@ class Proxify {
       }],
       kind: TDClass('tink.web.proxy.Remote.RemoteBase'.asTypePath([TPType(ctx.type.toComplex())])),
     }
-    
-    new haxe.macro.Printer().printTypeDefinition(t);
-    return t;
-    
   }
   
   static function remote():Type 

--- a/tests/Fake.hx
+++ b/tests/Fake.hx
@@ -38,8 +38,9 @@ class Fake {
   @:get public function complex(query: Complex, ?bar:String) 
     return query;
   
-  // @:post public function streaming(body:RealSource)
-  //   return body.all();
+  @:consumes('application/octet-stream')
+  @:post public function streaming(body:RealSource):RealSource
+    return body;
     
   @:post public function buffered(body:Bytes)
     return body;

--- a/tests/ProxyTest.hx
+++ b/tests/ProxyTest.hx
@@ -36,6 +36,10 @@ class ProxyTest {
     return proxy.complex(c).map(function (o) return assert(compare(c, o.sure())));
   }
   
+  public function streaming() {
+    return proxy.streaming('foo').next(function (o) return o.all()).next(o -> return assert(o.toString() == 'foo'));
+  }
+  
   public function typed() {
     return proxy.typed()
       .next(function (o) {

--- a/tests/ProxyTest.hx
+++ b/tests/ProxyTest.hx
@@ -37,7 +37,7 @@ class ProxyTest {
   }
   
   public function streaming() {
-    return proxy.streaming('foo').next(function (o) return o.all()).next(o -> return assert(o.toString() == 'foo'));
+    return proxy.streaming('foo').next(function (o) return o.all()).next(function(o) return assert(o.toString() == 'foo'));
   }
   
   public function typed() {


### PR DESCRIPTION
One problem is that `ResponseReader` forces me to return a Promise, so the return value of `proxy.streaming()` is `Promise<RealSource>`. Ideally it should be just `RealSource` I think.