### PR TITLE
Add scheme to URL (required for PHP target)

### DIFF
--- a/src/tink/web/proxy/Remote.hx
+++ b/src/tink/web/proxy/Remote.hx
@@ -55,7 +55,7 @@ abstract RemoteEndpoint(RemoteEndpointData) from RemoteEndpointData {
     return 
       client.request(
         new OutgoingRequest(
-          new OutgoingRequestHeader(method, '//' + this.host + uri(), this.headers),//TODO: consider putting protocol here
+          new OutgoingRequestHeader(method, (this.host.port == 443 ? 'https' : 'http') + '://' + this.host + uri(), this.headers),
           body
         )
       ).next(function (response) return reader.withHeader(response.header)(response.body));


### PR DESCRIPTION
Without a scheme in the PHP target, we get the error (e.g. for the httpbin example):
```
PHP Fatal error:  Uncaught ErrorException: fopen(//httpbin.org:80/get?name=Haxe): failed to open stream: No such file or directory
```
Assuming that port 443 => `https`, otherwise `http` is a little simplistic but probably covers 99% of use cases.