### PR TITLE
Add scheme to RemoteEndpoint.request<A>

### DIFF
--- a/dev.hxml
+++ b/dev.hxml
@@ -1,5 +1,6 @@
 tests.hxml
 -lib tink_web
+-lib tink_xml
 -lib travix
 -lib hxnodejs
 -js bin/node/tests.js

--- a/haxelib.json
+++ b/haxelib.json
@@ -19,6 +19,7 @@
 	"dependencies": {
 		"tink_http": "",
 		"tink_json": "",
+		"tink_xml": "",
 		"tink_querystring": ""
 	}
 }

--- a/src/tink/web/macros/MimeType.hx
+++ b/src/tink/web/macros/MimeType.hx
@@ -7,97 +7,93 @@ import haxe.macro.Type;
 using tink.MacroApi;
 
 abstract MimeType(String) from String to String {
-  
-  static function typedString(e:Expr) 
-    return switch Context.typeExpr(e) {
-      case { expr: TConst(TString(s)) }:
-        s;
-      case t: 
-        e.reject('Expected String but found $t');
-    }  
-  
-  static public function fromMeta(meta:MetaAccess, kind:String, old:Array<MimeType>) 
-    return switch [for (m in meta.extract(':$kind')) for (e in m.params) e] {
-      case []: old;
-      case v:
-        function isUnop(e:Expr)
-          return e.expr.match(EUnop(_, _, _));
-        
-        switch v.filter(isUnop) {
-          case []:
-            
-            [for (e in v) typedString(e)];
-            
-          case mixed if (mixed.length < v.length):
-            
-            mixed[0].reject('you must either modify or replace mime types');
-            
-          case all:
-            
-            var ret = old.copy();
-            
-            for (e in v)
-              switch e {
-                case (macro --$e) | (macro $e--):
-                  ret.remove(typedString(e));
-                case (macro ++$e) | (macro $e++):
-                  var s = typedString(e);
-                  while (ret.remove(s)) { }
-                  ret.push(s); 
-                default: 
-                  e.reject();
-              }
-              
-            ret;
-        }
-        
-    }
-  
-  static public var readers(default, null) = new Registry('reader', [
-    'application/json' => function (type:Type, pos:Position) {
-      var ct = type.toComplex({ direct: true });
-      return macro @:pos(pos) new tink.json.Parser<$ct>().tryParse;
-    },
-  ]);
-  static public var writers(default, null) = new Registry('writer', [
-    'application/json' => function (type:Type, pos:Position) {
-      var ct = type.toComplex( { direct: true } );
-      return macro @:pos(pos) new tink.json.Writer<$ct>().write;
-    },
-    'application/x-www-form-urlencoded' => function (type:Type, pos:Position) {
-      var ct = type.toComplex( { direct: true } );
-      return macro @:pos(pos) new tink.querystring.Builder<$ct>().stringify;
-    },
-  ]);
-  
+	static function typedString(e:Expr)
+		return switch Context.typeExpr(e) {
+			case {expr: TConst(TString(s))}:
+				s;
+			case t:
+				e.reject('Expected String but found $t');
+		}
+
+	static public function fromMeta(meta:MetaAccess, kind:String, old:Array<MimeType>)
+		return switch [for (m in meta.extract(':$kind')) for (e in m.params) e] {
+			case []: old;
+			case v:
+				function isUnop(e:Expr)
+					return e.expr.match(EUnop(_, _, _));
+				switch v.filter(isUnop) {
+					case []:
+						[for (e in v) typedString(e)];
+					case mixed if (mixed.length < v.length):
+						mixed[0].reject('you must either modify or replace mime types');
+					case all:
+						var ret = old.copy();
+						for (e in v)
+							switch e {
+								case(macro --$e) | (macro $e--):
+									ret.remove(typedString(e));
+								case(macro ++$e) | (macro $e++):
+									var s = typedString(e);
+									while (ret.remove(s)) {}
+									ret.push(s);
+								default:
+									e.reject();
+							}
+						ret;
+				}
+		}
+
+	static function xmlReader(type:Type, pos:Position) {
+		var ct = type.toComplex({direct: true});
+		return macro @:pos(pos) new tink.xml.Signature<$ct>().read;
+	}
+
+	static public var readers(default, null) = new Registry('reader', [
+		'application/json' => function(type:Type, pos:Position) {
+			var ct = type.toComplex({direct: true});
+			return macro @:pos(pos) new tink.json.Parser<$ct>().tryParse;
+		},
+		'text/xml' => xmlReader,
+		'application/xml' => xmlReader
+	]);
+	static public var writers(default, null) = new Registry('writer', [
+		'application/json' => function(type:Type, pos:Position) {
+			var ct = type.toComplex({direct: true});
+			return macro @:pos(pos) new tink.json.Writer<$ct>().write;
+		},
+		'application/x-www-form-urlencoded' => function(type:Type, pos:Position) {
+			var ct = type.toComplex({direct: true});
+			return macro @:pos(pos) new tink.querystring.Builder<$ct>().stringify;
+		},
+	]);
 }
 
 private class Registry {
-  var map:Map<MimeType, Type->Position->Expr>;
-  var kind:String;
-  
-  public function new(kind, map) {
-    this.kind = kind;
-    this.map = map;
-  }
-  
-  public function register(type:MimeType, reader:Type->Expr) 
-    if (map.exists(type))
-      throw 'Duplicate registration for type $type';
-        
-  public function get(options:Array<MimeType>, type, pos:Position) {
-    
-    for (a in options)
-      switch map[a] {
-        case null:
-        case gen: return { type: a, generator: gen(type, pos) };
-      }
-      
-    options = options.copy();
-    var last = options.pop();
-    return pos.error('No $kind available for '+ switch options {
-      case []: 'mime type $last';
-      default: 'any of the mime types ' + options.join(', ') + ' or $last';
-    }); 
-  }
+	var map:Map<MimeType, Type->Position->Expr>;
+	var kind:String;
+
+	public function new(kind, map) {
+		this.kind = kind;
+		this.map = map;
+	}
+
+	public function register(type:MimeType, reader:Type->Expr)
+		if (map.exists(type))
+			throw 'Duplicate registration for type $type';
+
+	public function get(options:Array<MimeType>, type, pos:Position) {
+		for (a in options)
+			switch map[a] {
+				case null:
+				case gen:
+					return {type: a, generator: gen(type, pos)};
+			}
+
+		options = options.copy();
+		var last = options.pop();
+		return pos.error('No $kind available for ' + switch options {
+			case []: 'mime type $last';
+			default: 'any of the mime types ' + options.join(', ') + ' or $last';
+		});
+	}
 }

--- a/src/tink/web/proxy/Remote.hx
+++ b/src/tink/web/proxy/Remote.hx
@@ -51,14 +51,15 @@ abstract RemoteEndpoint(RemoteEndpointData) from RemoteEndpointData {
       case v: Path.normalize(v.join('/'));
     }) + this.query;
   
-  public function request<A>(client:Client, method, body, reader:ResponseReader<A>):Promise<A>
-    return 
-      client.request(
-        new OutgoingRequest(
-          new OutgoingRequestHeader(method, '//' + this.host + uri(), this.headers),//TODO: consider putting protocol here
+  public function request<A>(client:Client, method, body, reader:ResponseReader<A>):Promise<A>{
+    var scheme = ~/:443$/.match(this.host) ? 'https' : 'http';
+    return client.request(
+      new OutgoingRequest(
+          new OutgoingRequestHeader(method, scheme + '://' + this.host + uri(), this.headers),//TODO: consider putting protocol here
           body
-        )
-      ).next(function (response) return reader.withHeader(response.header)(response.body));
+      )
+    ).next(function (response) return reader.withHeader(response.header)(response.body));
+  }
       
   @:from public static inline function fromHost(host:Host):RemoteEndpoint
     return new RemoteEndpoint(host);

--- a/tests.hxml
+++ b/tests.hxml
@@ -1,6 +1,7 @@
 -cp tests
 -main RunTests
 -lib deep_equal
+-lib tink_xml
 -lib tink_unittest
 # -lib tink_multipart
 


### PR DESCRIPTION
`sys.Http` throws an `Invalid URL` error message without this (somehow, scheme is reaching `StdClient` still blank, so url looks like `//website.com`)