### PR TITLE
In TestProxy could we use new RemoteEndpoint(null) for LocalContainer?

### DIFF
--- a/tests/ProxyTest.hx
+++ b/tests/ProxyTest.hx
@@ -29,7 +29,7 @@ class ProxyTest {
     container.run(function (req:IncomingRequest) {
       return DispatchTest.exec(req).recover(OutgoingResponse.reportError);
     });
-    proxy = new Remote<Fake>(client, new RemoteEndpoint(new Host('localhost', 80)));
+    proxy = new Remote<Fake>(client, new RemoteEndpoint(null));
   }
   
   public function complex() {


### PR DESCRIPTION
Right now we have `proxy = new Remote<Fake>(client, new RemoteEndpoint(new Host('localhost', 80)));`. Can we use the convention `proxy = new Remote<Fake>(client, new RemoteEndpoint(null));` here? 

I can see how it could be controversial (usually I would say `null` is not the tink way) but 

1. `new Host('localhost', 80)` is misleading since there is no listening socket in this case, and 
2. creating another type of `Remote` just for LocalContainer would be overkill. 

So which is better in your opinion, some fake `Host` or `null`?