### PR TITLE
Fix Proxiyfying RealSource params

### DIFF
--- a/src/tink/web/macros/Proxify.hx
+++ b/src/tink/web/macros/Proxify.hx
@@ -101,7 +101,7 @@ class Proxify {
                 var body = switch payload.toTypes().body {
                   case Flat(Plain(name), type) if(Context.getType('tink.io.Source.RealSource').unifiesWith(type)):
                     streaming = true;
-                    macro $i{name}.idealize(function(_) return tink.io.Source.EMPTY);
+                    macro tink.io.Source.RealSourceTools.idealize($i{name}, function(_) return tink.io.Source.EMPTY);
 
                   case Flat(Plain(name), type) if(Context.getType('tink.io.Source.IdealSource').unifiesWith(type)):
                     streaming = true;


### PR DESCRIPTION
Without this, errors with:
`Proxify.hx:104: characters 36-44 : tink.io.RealSource has no field idealize`