### PR TITLE
Add remote proxying. Fix incorrect type in macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ bin
 bin/node/tests.js
 node_modules
 /travix.n
+.haxelib/**
+.vscode/**

--- a/src/tink/web/macros/Proxify.hx
+++ b/src/tink/web/macros/Proxify.hx
@@ -65,6 +65,7 @@ class Proxify {
       fields: [for (f in routes) {
         pos: f.field.pos,
         name: f.field.name,
+        meta: f.field.meta.get(),
         kind: FFun({
           args: [for (arg in f.signature.args) switch arg.kind {
             case AKSingle(_, ATUser(_) | ATContext): continue;
@@ -156,7 +157,7 @@ class Proxify {
                   ret;
                 }
                 var endPoint = makeEndpoint(path, f, headers);
-                var bodyCt = streaming ? macro:tink.io.IdealSource : macro:tink.Chunk;
+                var bodyCt = streaming ? macro:tink.io.Source.IdealSource : macro:tink.Chunk;
 
                 macro @:pos(f.field.pos) {
                   var __body__:$bodyCt = $body;

--- a/tests/RemoteEndpoints.hx
+++ b/tests/RemoteEndpoints.hx
@@ -63,9 +63,10 @@ class RemoteEndpoints {
   }
 
   // got error: tests/RemoteEndpoints.hx:67: characters 29-35 : tink.web.proxy.RemoteEndpoint has no field scheme
-  // public function issue123() {
-  //   final endpoint = new RemoteEndpoint(new tink.url.Host("127.0.0.1", 8081));
-  //   asserts.assert(endpoint.scheme == '');
-  //   return asserts.done();
-  // }
+  public function issue123() @:privateAccess {
+    final endpoint:Dynamic = new RemoteEndpoint(new tink.url.Host("127.0.0.1", 8081));
+    
+    asserts.assert(endpoint.scheme == null);
+    return asserts.done();
+  }
 }

--- a/tests/RemoteEndpoints.hx
+++ b/tests/RemoteEndpoints.hx
@@ -62,9 +62,10 @@ class RemoteEndpoints {
     return asserts.done();
   }
 
-  public function issue123() {
-    final endpoint = new RemoteEndpoint(new tink.url.Host("127.0.0.1", 8081));
-    asserts.assert(endpoint.scheme == '');
-    return asserts.done();
-  }
+  // got error: tests/RemoteEndpoints.hx:67: characters 29-35 : tink.web.proxy.RemoteEndpoint has no field scheme
+  // public function issue123() {
+  //   final endpoint = new RemoteEndpoint(new tink.url.Host("127.0.0.1", 8081));
+  //   asserts.assert(endpoint.scheme == '');
+  //   return asserts.done();
+  // }
 }

--- a/tests/RemoteEndpoints.hx
+++ b/tests/RemoteEndpoints.hx
@@ -64,7 +64,7 @@ class RemoteEndpoints {
 
   // got error: tests/RemoteEndpoints.hx:67: characters 29-35 : tink.web.proxy.RemoteEndpoint has no field scheme
   public function issue123() @:privateAccess {
-    final endpoint:Dynamic = new RemoteEndpoint(new tink.url.Host("127.0.0.1", 8081));
+    final endpoint = new RemoteEndpoint(new tink.url.Host("127.0.0.1", 8081));
     
     asserts.assert(endpoint.scheme == '');
     return asserts.done();

--- a/tests/RemoteEndpoints.hx
+++ b/tests/RemoteEndpoints.hx
@@ -66,7 +66,7 @@ class RemoteEndpoints {
   public function issue123() @:privateAccess {
     final endpoint:Dynamic = new RemoteEndpoint(new tink.url.Host("127.0.0.1", 8081));
     
-    asserts.assert(endpoint.scheme == null);
+    asserts.assert(endpoint.scheme == '');
     return asserts.done();
   }
 }


### PR DESCRIPTION
This will allow you to return `tink.web.proxy.Remote` instances from routes like so:
```haxe
	@:sub("/@me")
	@:async public function me(user:Session.User):tink.web.proxy.Remote<UserProxy> {
		return duckProxy.users(AppSettings.config.wildDuck.apiKey).get(user.duck.id);
	}
```
Then, using [this](https://github.com/Brave-Pi/bp_duck/blob/master/src/bp/duck/proxy/WildDuckProxy.hx#L150) remote interface as an example:
```http
GET /api/@me/mailboxes/61cbf39ac3b56500072d77d8/messages/18 HTTP/1.1
Host: localhost:3000
Content-Type: application/json
x-access-token: <access-token>
{
	"username": "<username>",
	"password": "<password>"
}------WebKitFormBoundary7MA4YWxkTrZu0gW--
```

Response:
```haxe
{
    "answered": false,
    "attachments": [],
    "contentType": {
        "params": {
            "boundary": "000000000000df2f8705d53e1902"
        },
        "value": "multipart/alternative"
    },
    "date": "2022-01-10T17:59:31.000Z",
    "deleted": false,
    "draft": false,
    "envelope": {
        "from": "gabriel.speed.bullock@gmail.com",
        "rcpt": [
            {
                "formatted": "webmaster@gabedev.tech",
                "value": "webmaster@gabedev.tech"
            }
        ]
    },
    "flagged": false,
    "forwarded": false,
    "from": {
        "address": "gabriel.speed.bullock@gmail.com",
        "name": "Gabriel Speed"
    },
    "html": [
        "<div dir=\"auto\">You made the Protoverse, Usernet, GunChain and Boisly</div>"
    ],
    "id": 18,
    "mailbox": "61cbf39ac3b56500072d77d8",
    "messageId": "<CAFoxTFqQo5XsNbX-6QA+X+60TWY0CY7f5p4+ZUYtcHbuz3+R4Q@mail.gmail.com>",
    "metaData": {},
    "seen": false,
    "size": 3565,
    "subject": "Protoverse",
    "success": true,
    "text": "You made the Protoverse, Usernet, GunChain and Boisly",
    "thread": "61dc740fe9e4e70012b37833",
    "to": [
        {
            "address": "gabe4haxelang@gmail.com",
            "name": ""
        },
        {
            "address": "webmaster@gabedev.tech",
            "name": ""
        }
    ],
    "user": "61cbf39ac3b56500072d77d7",
    "verificationResults": {
        "dkim": "gmail.com",
        "spf": "gmail.com",
        "tls": {
            "name": "TLS_AES_256_GCM_SHA384",
            "version": "TLSv1.3"
        }
    }
}
```
