### PR TITLE
Remote proxying (and support for file piping)

### DIFF
--- a/src/tink/web/macros/Proxify.hx
+++ b/src/tink/web/macros/Proxify.hx
@@ -65,6 +65,7 @@ class Proxify {
       fields: [for (f in routes) {
         pos: f.field.pos,
         name: f.field.name,
+        meta: f.field.meta.get(),
         kind: FFun({
           args: [for (arg in f.signature.args) switch arg.kind {
             case AKSingle(_, ATUser(_) | ATContext): continue;
@@ -156,7 +157,7 @@ class Proxify {
                   ret;
                 }
                 var endPoint = makeEndpoint(path, f, headers);
-                var bodyCt = streaming ? macro:tink.io.IdealSource : macro:tink.Chunk;
+                var bodyCt = streaming ? macro:tink.io.Source.IdealSource : macro:tink.Chunk;
 
                 macro @:pos(f.field.pos) {
                   var __body__:$bodyCt = $body;

--- a/src/tink/web/routing/Response.hx
+++ b/src/tink/web/routing/Response.hx
@@ -15,6 +15,10 @@ abstract Response(OutgoingResponse) from OutgoingResponse to OutgoingResponse {
   static public function ofChunk(c:Chunk, ?contentType:String = BINARY)
     return binary(null, contentType, c);
 
+  @:from static function fromIncomingresponse(r:IncomingResponse):Response
+		return new OutgoingResponse(new ResponseHeader(r.header.statusCode, r.header.statusCode, @:privateAccess r.header.fields.map(header ->
+			new HeaderField(header.name, header.value))), r.body.idealize(function(_) return Source.EMPTY));
+
   @:from static function ofString(s:String):Response
     return textual('text/plain', s);
 


### PR DESCRIPTION
See: https://github.com/haxetink/tink_web/pull/128

This also allows you to pipe files (and pretty much any HTTP response) through to the client from `tink_web` by returning marking the return type on the designated remote interface for the route you'd like to receive raw as a `tink.web.routing.Response` (done by [adding a conversion from `tink.http.IncomingResponse`](https://github.com/Brave-Pi/tink_web/blob/7723c52e023dcdfed7792a58e410d7b44832287d/src/tink/web/routing/Response.hx#L18)

