### PR TITLE
Safely navigate nullable objects

### DIFF
--- a/src/tink/web/macros/Arguments.hx
+++ b/src/tink/web/macros/Arguments.hx
@@ -27,7 +27,7 @@ class Arguments {
             name: field.name,
             type: field.type,
             optional: field.meta.has(':optional'),
-            target: getArgTarget(paths, params, Drill(name, field.name), a.opt, pos),
+            target: getArgTarget(paths, params, Drill({name: name, nullable: field.meta.has(':optional')}, field.name), a.opt, pos),
           }]);
         case [name, _]:
           AKSingle(
@@ -71,7 +71,7 @@ class Arguments {
   static function stringifyArgAccess(access:ArgAccess) {
     return switch access {
       case Plain(name): name;
-      case Drill(name, field): '$name.$field';
+      case Drill({name: name}, field): '$name.$field';
     }
   }
 
@@ -101,7 +101,7 @@ typedef RouteArg = {
 
 enum ArgAccess {
   Plain(name:String);
-  Drill(name:String, field:String);
+  Drill(object:{name:String, nullable:Bool}, field:String);
 }
 
 enum ArgKind {

--- a/src/tink/web/macros/Parameters.hx
+++ b/src/tink/web/macros/Parameters.hx
@@ -21,6 +21,10 @@ class Parameters {
           if (reserved(name)) p.reject('`$name` is reserved');
           if (!types.exists(name)) p.reject('`$name` does not appear in the function argument list');
         }
+        
+        function isNullable(name:String) {
+          return types[name].match(TAbstract(_.get() => {name: 'Null', pack: []}, _));
+        }
 
         function hasField(type:Type, name:String) {
           return switch type {
@@ -40,7 +44,7 @@ class Parameters {
             validate(name);
             switch types[name].reduce() {
               case TAnonymous(_.get() => {fields: fields}):
-                for(field in fields) add(Drill(name, field.name), LOCATION_FACTORY[pos](getParamName(field)));
+                for(field in fields) add(Drill({name: name, nullable: isNullable(name)}, field.name), LOCATION_FACTORY[pos](getParamName(field)));
               case _:
                 p.reject('`$name` should be anonymous structure');
             }
@@ -52,12 +56,12 @@ class Parameters {
           case macro $i{name}.$field in $i{pos = 'query' | 'header' | 'body'}:
             validate(name);
             if(!hasField(types[name], field)) p.reject('`$name` does not has field "$field"');
-            add(Drill(name, field), LOCATION_FACTORY[pos](field));
+            add(Drill({name: name, nullable: isNullable(name)}, field), LOCATION_FACTORY[pos](field));
 
           case macro $i{name}.$field = $i{pos = 'query' | 'header' | 'body'}[$v{(native:String)}]:
             validate(name);
             if(!hasField(types[name], field)) p.reject('`$name` does not has field "$field"');
-            add(Drill(name, field), LOCATION_FACTORY[pos](native));
+            add(Drill({name: name, nullable: isNullable(name)}, field), LOCATION_FACTORY[pos](native));
 
           default:
             p.reject('Invalid syntax for @:params, only the following are supported:
@@ -90,8 +94,8 @@ class Parameters {
 
   static function conflictAccess(a1:ArgAccess, a2:ArgAccess) {
     return switch [a1, a2] {
-      case [Plain(n1), Plain(n2)] | [Drill(n1, _), Plain(n2)] | [Plain(n1), Drill(n2, _)]: n1 == n2;
-      case [Drill(n1, f1), Drill(n2, f2)]: n1 == n2 && f1 == f2;
+      case [Plain(n1), Plain(n2)] | [Drill({name: n1}, _), Plain(n2)] | [Plain(n1), Drill({name: n2}, _)]: n1 == n2;
+      case [Drill({name: n1}, f1), Drill({name: n2}, f2)]: n1 == n2 && f1 == f2;
     }
   }
 
@@ -107,7 +111,7 @@ class Parameters {
 
   public function byName(name:String):Array<ParamMapping> {
     return params.filter(function(p) return switch p.access {
-      case Plain(n) | Drill(n, _): n == name;
+      case Plain(n) | Drill({name: n}, _): n == name;
     });
   }
 
@@ -115,7 +119,7 @@ class Parameters {
     for(p in params)
       switch [access, p.access] {
         case [Plain(n1), Plain(n2)] if(n1 == n2): return Some(p);
-        case [Drill(n1, f1), Drill(n2, f2)] if(n1 == n2 && f1 == f2): return Some(p);
+        case [Drill({name: n1}, f1), Drill({name: n2}, f2)] if(n1 == n2 && f1 == f2): return Some(p);
         case _:
       }
     return None;

--- a/src/tink/web/macros/Paths.hx
+++ b/src/tink/web/macros/Paths.hx
@@ -158,7 +158,7 @@ class Path {
     for(part in parts)
       switch [access, part] {
         case [Plain(n1), PCapture(Plain(n2))] if(n1 == n2): return Some(part);
-        case [Drill(n1, f1), PCapture(Drill(n2, f2))] if(n1 == n2 && f1 == f2): return Some(part);
+        case [Drill({name: n1}, f1), PCapture(Drill({name: n2}, f2))] if(n1 == n2 && f1 == f2): return Some(part);
         case _:
       }
     return None;

--- a/src/tink/web/macros/Proxify.hx
+++ b/src/tink/web/macros/Proxify.hx
@@ -16,7 +16,7 @@ class Proxify {
     function val(p:PathPart)
       return switch p {
         case PCapture(Plain(name)): macro (($i{name} : tink.Stringly) : tink.url.Portion);
-        case PCapture(Drill(name, field)): throw 'TODO';
+        case PCapture(Drill({name: name}, field)): throw 'TODO';
         case PConst(s): macro $s;
       }
 
@@ -110,7 +110,7 @@ class Proxify {
                     var writer = w.generator;
                     macro ${writer}($i{name});
 
-                  case Flat(Drill(name, field), type):
+                  case Flat(Drill({name: name}, field), type):
                     throw "TODO";
 
                   case Object(TAnonymous([])):

--- a/src/tink/web/macros/Route.hx
+++ b/src/tink/web/macros/Route.hx
@@ -80,7 +80,7 @@ class Route {
             for(field in fields)
               switch field.target {
                 case ATParam(kind):
-                  arr.push({id: id++, access: Drill(arg.name, field.name), type: field.type, optional: optional || field.optional, kind: kind});
+                  arr.push({id: id++, access: Drill({name: arg.name, nullable: arg.optional}, field.name), type: field.type, optional: optional || field.optional, kind: kind});
                 case _: // skip
               }
           case _: // skip
@@ -209,12 +209,15 @@ abstract Payload(Pair<Position, Array<{id:Int, access:ArgAccess, type:Type, opti
           add(query, macro $i{name});
         case [Plain(name), PKHeader(_)]:
           add(header, macro $i{name});
-        case [Drill(name, field), PKBody(Some(_))]:
-          add(body, macro $p{[name, field]});
-        case [Drill(name, field), PKQuery(_)]:
-          add(query, macro $p{[name, field]});
-        case [Drill(name, field), PKHeader(_)]:
-          add(header, macro $p{[name, field]});
+        case [Drill({name: name, nullable: nullable}, field), PKBody(Some(_))]:
+          final access = macro $p{[name, field]};
+          add(body, nullable ? macro ($i{name} == null ? null : $access) : access);
+        case [Drill({name: name, nullable: nullable}, field), PKQuery(_)]:
+          final access = macro $p{[name, field]};
+          add(query, nullable ? macro ($i{name} == null ? null : $access) : access);
+        case [Drill({name: name, nullable: nullable}, field), PKHeader(_)]:
+          final access = macro $p{[name, field]};
+          add(header, nullable ? macro ($i{name} == null ? null : $access) : access);
       }
     }
 

--- a/src/tink/web/macros/Routing.hx
+++ b/src/tink/web/macros/Routing.hx
@@ -91,7 +91,7 @@ class Routing {
         case PCapture(Plain(name)):
           captured[name] = true;
           macro $i{name};
-        case PCapture(Drill(name, field)):
+        case PCapture(Drill({name: name}, field)):
           throw "TODO";
       }
 
@@ -519,13 +519,13 @@ class Routing {
           plain(name, macro __query__);
         case [Plain(name), PKHeader(_)]:
           plain(name, macro __header__);
-        case [Drill(name, field), PKBody(None)]:
+        case [Drill({name: name}, field), PKBody(None)]:
           drill(name, field, macro __body__, true);
-        case [Drill(name, field), PKBody(Some(_))]:
+        case [Drill({name: name}, field), PKBody(Some(_))]:
           drill(name, field, macro __body__);
-        case [Drill(name, field), PKQuery(_)]:
+        case [Drill({name: name}, field), PKQuery(_)]:
           drill(name, field, macro __query__);
-        case [Drill(name, field), PKHeader(_)]:
+        case [Drill({name: name}, field), PKHeader(_)]:
           drill(name, field, macro __header__);
       }
     }

--- a/tests/Fake.hx
+++ b/tests/Fake.hx
@@ -193,6 +193,10 @@ class Fake {
   @:post public function optional(body: { foo:String, ?bar: Int })
     return {bar:body.bar};
 
+  @:params(nullableValue = query)
+  @:post public function optionalQuery(?nullableValue: { foo:String })
+    return {foo: nullableValue == null ? null : nullableValue.foo};
+  
   @:restrict(user.id == a)
   @:sub('/sub/$a/$b')
   public function sub(a, b) {

--- a/tests/Fake.hx
+++ b/tests/Fake.hx
@@ -193,8 +193,13 @@ class Fake {
   @:post public function optional(body: { foo:String, ?bar: Int })
     return {bar:body.bar};
 
+  
+
+  @:post public function nullableQuery1(?query: { foo:String })
+    return {foo: query == null ? null : query.foo};
+  
   @:params(nullableValue = query)
-  @:post public function optionalQuery(?nullableValue: { foo:String })
+  @:post public function nullableQuery2(?nullableValue: { foo:String })
     return {foo: nullableValue == null ? null : nullableValue.foo};
   
   @:restrict(user.id == a)

--- a/tests/ProxyTest.hx
+++ b/tests/ProxyTest.hx
@@ -238,8 +238,18 @@ class ProxyTest {
     return asserts;
   }
 
-  public function optionalQuery() {
-    proxy.optionalQuery()
+  public function nullableQuery1() {
+    proxy.nullableQuery1()
+      .next(function (o) {
+        asserts.assert(o.foo == null);
+        return Noise;
+      })
+      .handle(asserts.handle);
+    return asserts;
+  }
+
+  public function nullableQuery2() {
+    proxy.nullableQuery2()
       .next(function (o) {
         asserts.assert(o.foo == null);
         return Noise;

--- a/tests/ProxyTest.hx
+++ b/tests/ProxyTest.hx
@@ -231,7 +231,17 @@ class ProxyTest {
   public function int() {
     proxy.int(1)
       .next(function (o) {
-        o == 1;
+        asserts.assert(o == 1);
+        return Noise;
+      })
+      .handle(asserts.handle);
+    return asserts;
+  }
+
+  public function optionalQuery() {
+    proxy.optionalQuery()
+      .next(function (o) {
+        asserts.assert(o.foo == null);
         return Noise;
       })
       .handle(asserts.handle);


### PR DESCRIPTION
Proxy was borken when query/body/header object is nullable:

```haxe
public function nullableQuery1(?query: { foo:String });
```

should be fixed in this PR