### PR TITLE
Added arguments to RemoteEndpoint example

### DIFF
--- a/advanced/remoting.md
+++ b/advanced/remoting.md
@@ -51,7 +51,7 @@ import tink.url.Host;
 
 class Client {
 	static function main() {
-		var remote = new Remote<Root>(new JsClient(), new RemoteEndpoint(new Host('httpbin.org', 80)));
+		var remote = new Remote<Root>(new JsClient(), new RemoteEndpoint(new Host('httpbin.org', 80),"","http"));
 		remote.get({name: 'Haxe'}).handle(function(o) switch o {
 			case Success(result):
 				trace($type(result));


### PR DESCRIPTION
Node was complaining about a missing scheme when running the example.